### PR TITLE
Fix issue-7

### DIFF
--- a/less/images.less
+++ b/less/images.less
@@ -90,7 +90,7 @@
   .icon-img('../node_modules/jenkins-core-theme/images/settings.svg', @color-grey);
 }
 
-.icon-up, .task-icon-link[href='/'] img {
+.icon-up, [src$='up.png'] {
   .icon-img('../node_modules/jenkins-core-theme/images/arrow_back.svg', @color-grey);
 }
 
@@ -396,13 +396,3 @@
   width: auto !important;
   padding: 0 !important;
 }
-
-.task-icon-link[href='/'] {
-  img {
-    padding: 36px 0 0 36px !important;
-    filter: brightness(10000);
-  }
-}
-
-
-


### PR DESCRIPTION
Fix issue #7
Removes the href matching for the up/back icon.

When Jenkins is served from the root of a web server, this was causing the 'Back to Dashboard' menu icon to be hidden in all themes that import /jenkins-core-theme/images.less .